### PR TITLE
Add .nojekyll file to deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "next build && next export -o build",
     "start": "next start",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages --dotfiles -d build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Description

Add .nojekyll file to deploy so gh-pages does not ignore the _next folder.

Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>