### PR TITLE
Add key to image meta tags and use full url

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -2,6 +2,8 @@ import Head from 'next/head'
 import Navbar from './navbar'
 import Footer from './footer'
 
+const cardImageURL = new URL("/images/pilot.png", process.env.PUBLIC_URL).toString()
+
 export default function Layout({ children }) {
   return (
     <div className="bg-white">
@@ -21,9 +23,10 @@ export default function Layout({ children }) {
         
         <meta property="og:title" content="Actuated - Blazing fast CI" key="og_title"/>
         <meta property="og:description" content="Keep your team productive &amp; focused with blazing fast CI" key="og_description"/>
-        <meta property="og:image" content="/images/pilot.png" />
+        <meta property="og:image" content={cardImageURL} key="og_image"/>
+        <meta name="twitter:image:src" content={cardImageURL} key="tw_image" />
 
-        <meta name="twitter:card" content="summary_large_image"  />
+        <meta name="twitter:card" content="summary_large_image" key="tw_card"/>
 
         <title>Actuated - Blazing fast CI</title>
       </Head>

--- a/pages/blog/[id].js
+++ b/pages/blog/[id].js
@@ -30,8 +30,8 @@ export default function Post({ post }) {
 
         {post.image &&
           <>
-            <meta name="twitter:image:src" content={imageURL} /> 
-            <meta property="og:image" content={imageURL} />
+            <meta name="twitter:image:src" content={imageURL} key="tw_image" /> 
+            <meta property="og:image" content={imageURL} key="og_image"/>
           </>
         }
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- The default social sharing image was always diplayed even if a blog post had its own image.
- Use the full url in meta tags to make sure embedding content works on all platform.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Display images correctly when embedding or sharing site on social media.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified headers visually.

Tested with discord and twitter card validator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.